### PR TITLE
Replace "clientOptions" with "options" in documentation

### DIFF
--- a/docus/content/2.Setting/1.frontend.md
+++ b/docus/content/2.Setting/1.frontend.md
@@ -45,7 +45,7 @@ Full documentation [on Meiliserch client page](https://github.com/meilisearch/in
 ```ts{}[nuxt.config.ts]
 meilisearch: {
   ...
-  clientOptions: {
+  options: {
         placeholderSearch: true,
         paginationTotalHits: 200,
         finitePagination: false,


### PR DESCRIPTION
The documentation does not currently represent the correct option name for configuring client options. This just updates the documentation to prevent confusion