### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,7 @@ Read [Nuxt Meilisearch documentation](https://nuxt-meilisearch.vercel.app).
 Install nuxt-meilisearch:
 
 ```bash
-# with npm
-npm install nuxt-meilisearch
-
-# with yarn
-yarn add nuxt-meilisearch
-
-# with pnpm
-pnpm add nuxt-meilisearch
+npx nuxi@latest module add meilisearch
 ```
 
 > [!WARNING]

--- a/docus/content/0.index.md
+++ b/docus/content/0.index.md
@@ -108,7 +108,7 @@ cta:
 secondary:
   - Open on GitHub →
   - https://github.com/xlanex6/nuxt-meilisearch
-snippet: npm i -D nuxt-meilisearch
+snippet: npx nuxi@latest module add meilisearch
 features: 
   - Easy integration with MeilisearchJS lib
   - Support for Vue Algolia Vue 3 InstantSearch components (optional)

--- a/docus/content/1.getting-started/1.setup.md
+++ b/docus/content/1.getting-started/1.setup.md
@@ -9,18 +9,9 @@ Check the [Nuxt.js documentation](https://nuxtjs.org/api/configuration-modules#t
 ## Installation
 
 Add `nuxt-meilisearch` dependency to your project:
-
-::code-group
-  ```bash [pnpm]
-  pnpm add -D nuxt-meilisearch
-  ```
-  ```bash [yarn]
-  yarn add --dev nuxt-meilisearch
-  ```
-  ```bash [npm]
-  npm i --save-dev nuxt-meilisearch
-  ```
-::
+```bash
+npx nuxi@latest module add meilisearch
+```
 
 Then ddit your `nuxt.config.js` to load the module:
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
