### PR TITLE
Fixed some typos

### DIFF
--- a/docus/content/3.Server-Side/2.exemple.md
+++ b/docus/content/3.Server-Side/2.exemple.md
@@ -1,5 +1,5 @@
 ---
-title: Exemple
+title: Example
 layout: default
 ---
 
@@ -9,19 +9,18 @@ From your API server route, you can add a document to specific index.
 
 ```ts{}[server/api/myRoute]
 export default defineEventHandler(async (event) => {
+  const addRecordRes = await $meilisearch.index("movies").addDocuments([
+    {
+      id: 999999994234,
+      title: "Batman Unmasked: The Psychology of the Dark Knight",
+      poster: "https://image.tmdb.org/t/p/w1280/jjHu128XLARc2k4cJrblAvZe0HE.jpg",
+      overview: "Delve into the world of Batman and the vigilante justice tha",
+      release_date: "2008-07-15",
+    },
+  ])
 
-   const addRecordRes = await $meilisearch.index('movies').addDocuments(
-     {
-       id: 999999994234,
-       title: 'Batman Unmasked: The Psychology of the Dark Knight',
-       poster: 'https://image.tmdb.org/t/p/w1280/jjHu128XLARc2k4cJrblAvZe0HE.jpg',
-       overview: 'Delve into the world of Batman and the vigilante justice tha',
-       release_date: '2008-07-15'
-     }
-   )
-
-   return { myCustomResponse: "Document is on the way....", addRecordRes }
-}
+  return { myCustomResponse: "Document is on the way....", addRecordRes }
+})
 ```
 
 All options from Meiliseach JS SDK are available.


### PR DESCRIPTION
Perhaps make the `adminApiKey` default for users that run mellisearch locally? Because it only seems to require a single master key
See also https://github.com/xlanex6/nuxt-meilisearch/issues/131